### PR TITLE
locality not showing in employee dashboard fixed

### DIFF
--- a/web/rainmaker/packages/employee/src/modules/employee/Inbox/components/TableData/index.js
+++ b/web/rainmaker/packages/employee/src/modules/employee/Inbox/components/TableData/index.js
@@ -411,8 +411,27 @@ class TableData extends Component {
         })
 
         if (endpoints.length > 0) {
-          const resp = await multiHttpRequest(endpoints, "search", queries, requestBodies)
-          resp && resp.map(res => {
+          let resp;
+          try {
+            resp = await multiHttpRequest(endpoints, "search", queries, requestBodies)
+          } catch (multiErr) {
+            console.warn('[multiHttpRequest failed, trying individual requests]', multiErr.message);
+            // Fallback: try each endpoint individually incase some endpoints fail
+            resp = await Promise.all(
+              endpoints.map((endpoint, idx) =>
+                httpRequest(endpoint, "search", queries[idx] || [], requestBodies[idx] || {})
+                  .catch(err => {
+                    console.warn(`[Endpoint ${idx}] ${endpoint} failed:`, err.message);
+                    return null; // Return null for failed endpoint, continue with others
+                  })
+              )
+            );
+          }
+          resp && resp.map((res, idx) => {
+            if (!res) {
+              console.warn(`[Skipping null response at index ${idx}]`);
+              return;
+            }
             if (res && res.Localities) {
               res.Localities.forEach(loc => {
                 this.localityCache[loc.referencenumber] = loc;


### PR DESCRIPTION
Cause: NOC, BPA and BS locality fetch api errors leading to the request ignoring the successfull endpoint

locality api multihttprequest added in try catch - request fetched per endpoint if one endpoint fails to prevent the whole request from failing and accessing the data of the successfull endpoints